### PR TITLE
Adds hazelcast-kubernetes image

### DIFF
--- a/hazelcast-kubernetes/Dockerfile
+++ b/hazelcast-kubernetes/Dockerfile
@@ -1,0 +1,10 @@
+ARG BASE_IMAGE=e2eteam/java:openjdk-8-jre
+FROM $BASE_IMAGE
+
+# download the Kubernetes Hazelcast bootstrapper.
+ADD https://github.com/pires/hazelcast-kubernetes-bootstrapper/releases/download/3.8_1/hazelcast-kubernetes-bootstrapper-3.8_1.jar /bootstrapper.jar
+
+# expose port for Hazelcast.
+EXPOSE 5701/tcp
+
+ENTRYPOINT ["java", "-jar", "/bootstrapper.jar"]


### PR DESCRIPTION
The Hazelcast Kubernetes boostrapper will try to contact the Kubernetes
API when starting (needed for scaling). Thus, the container must be able
to resolve the Kubernetes service DNS name and contact it.