### PR TITLE
dnsutils: Sets extension for hostname

### DIFF
--- a/dnsutils/Dockerfile
+++ b/dnsutils/Dockerfile
@@ -5,6 +5,6 @@ ENV chocolateyUseWindowsCompression false
 RUN powershell -Command \
 iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1')); \
 choco feature disable --name showDownloadProgress
-ADD hostname.exe /busybox/hostname
+ADD hostname.exe /busybox/hostname.exe
 RUN powershell -Command choco install bind-toolsonly --version 9.10.3 -y
 ENTRYPOINT ["cmd.exe", "/s", "/c"]

--- a/jessie-dnsutils/Dockerfile
+++ b/jessie-dnsutils/Dockerfile
@@ -5,6 +5,6 @@ ENV chocolateyUseWindowsCompression false
 RUN powershell -Command \
 iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1')); \
 choco feature disable --name showDownloadProgress
-ADD hostname.exe /busybox/hostname
+ADD hostname.exe /busybox/hostname.exe
 RUN powershell -Command choco install bind-toolsonly --version 9.10.3 -y
 ENTRYPOINT ["cmd.exe", "/s", "/c"]


### PR DESCRIPTION
Because the .exe extension was not set, the executable was ignored,
and the default hostname.exe was being executed instead.