### PR TITLE
dnsutils: Adds getent command

### DIFF
--- a/dnsutils/Dockerfile
+++ b/dnsutils/Dockerfile
@@ -6,5 +6,6 @@ RUN powershell -Command \
 iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1')); \
 choco feature disable --name showDownloadProgress
 ADD hostname.exe /busybox/hostname.exe
+ADD getent.exe /busybox/getent.exe
 RUN powershell -Command choco install bind-toolsonly --version 9.10.3 -y
 ENTRYPOINT ["cmd.exe", "/s", "/c"]

--- a/go_files/getent/getent.go
+++ b/go_files/getent/getent.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"regexp"
+)
+
+
+func check(e error) {
+	if e != nil {
+		panic(e)
+	}
+}
+
+func getent(name string) string {
+	var content string;
+	hosts_file := "C:/Windows/System32/drivers/etc/hosts"
+
+	if name == "" {
+		content, err := ioutil.ReadFile(hosts_file)
+		check(err)
+		return string(content)
+	}
+
+	file, err := os.Open(hosts_file)
+	check(err)
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	r, _ := regexp.Compile(fmt.Sprintf("^[^#].*[\\s]+%s($|\\s)", name))
+	for scanner.Scan() {
+		content = scanner.Text()
+		if r.MatchString(content) {
+			return content
+		}
+	}
+
+	err = scanner.Err()
+	check(err)
+	return ""
+}
+
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println(fmt.Sprintf("Expected usage: %s hosts [entry]", os.Args[0]))
+		os.Exit(1)
+	}
+
+	entry := "";
+	if len(os.Args) > 2 {
+		entry = os.Args[2]
+	}
+
+	result := getent(entry)
+	if result != "" {
+		fmt.Println(result)
+	}
+}

--- a/jessie-dnsutils/Dockerfile
+++ b/jessie-dnsutils/Dockerfile
@@ -6,5 +6,6 @@ RUN powershell -Command \
 iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1')); \
 choco feature disable --name showDownloadProgress
 ADD hostname.exe /busybox/hostname.exe
+ADD getent.exe /busybox/getent.exe
 RUN powershell -Command choco install bind-toolsonly --version 9.10.3 -y
 ENTRYPOINT ["cmd.exe", "/s", "/c"]


### PR DESCRIPTION
Some tests are executing getent in order to get an entry from the
hosts file, but that command does not exist on Windows.

This patch creates a golang equivalent and includes it in the dnsutils
and jessie-dnsutils images.