### PR TITLE
liveness: Adds /tmp folder

### DIFF
--- a/liveness/Dockerfile
+++ b/liveness/Dockerfile
@@ -16,3 +16,4 @@ ARG BASE_IMAGE=microsoft/windowsservercore:1803
 FROM $BASE_IMAGE
 
 COPY server.exe /server
+RUN mkdir C:\tmp


### PR DESCRIPTION
Some tests like "[k8s.io] Probing container  should be restarted with a exec "cat /tmp/health" liveness probe [NodeConformance] [Conformance]" are trying to create a file into the /tmp folder, but it doesn't exist, which can lead to test failures.

This commit adds the /tmp folder.