### PR TITLE
hostexec: Adds nc.exe with extended functionalities

### DIFF
--- a/hostexec/Dockerfile
+++ b/hostexec/Dockerfile
@@ -1,3 +1,4 @@
 ARG BASE_IMAGE=e2eteam/busybox:1.29
 FROM $BASE_IMAGE
+ADD https://github.com/diegocr/netcat/raw/master/nc.exe /bin/nc.exe
 ENTRYPOINT ["cmd.exe", "/s", "/c", "sleep", "3600"]


### PR DESCRIPTION
Busybox's nc.exe is a lot more limited in functionality, causing some tests to fail. Which is why the current version of the busybox image doesn't contain the nc.exe executable.