### PR TITLE
redis: Base image on busybox

### DIFF
--- a/redis/Dockerfile
+++ b/redis/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=microsoft/windowsservercore:1803
+ARG BASE_IMAGE=e2eteam/busybox:1.29
 FROM $BASE_IMAGE
 EXPOSE 6379
 WORKDIR /redis


### PR DESCRIPTION
Some tests are trying to execute bash scripts, which do not exist on Windows. Basing the redis image on busybox fixes this issue.