### PR TITLE
Fixes ignored .go files issue

### DIFF
--- a/Utils.ps1
+++ b/Utils.ps1
@@ -9,7 +9,7 @@ function BuildGoFiles($folders) {
 
     Write-Verbose "Building Go items..."
     foreach ($folder in $folders) {
-        $items = Get-ChildItem -Recurse $folder | ? Name -Match ".*.go(lnk)$" | ? Name -NotMatch "util"
+        $items = Get-ChildItem -Recurse $folder | ? Name -Match ".*.go(lnk)?$" | ? Name -NotMatch "util"
         foreach ($item in $items) {
             $exePath = Join-Path $item.DirectoryName ($item.BaseName + ".exe")
             if (Test-Path $exePath) {


### PR DESCRIPTION
There's a small issue in the regex used to filter out the non-golang related files, causing all .go files to be ignored when building the binaries.

This patch solves the issue.